### PR TITLE
Error corregido en OtherInfoWindow

### DIFF
--- a/app/src/main/java/ayds/winchester/songinfo/moredetails/fulllogic/OtherInfoWindow.kt
+++ b/app/src/main/java/ayds/winchester/songinfo/moredetails/fulllogic/OtherInfoWindow.kt
@@ -61,8 +61,8 @@ class OtherInfoWindow : AppCompatActivity() {
     private fun formatArtistInfo(artist: WikipediaArtist?): String {
         return when(artist){
             is WikipediaArtist ->
-                if (artist.isLocallyStored) "[*]" else "" +
-                formatDescription(artist.description, artist.name)
+                    (if (artist.isLocallyStored) "[*]" else "") +
+                    formatDescription(artist.description, artist.name)
 
             else -> "No Results"
         }


### PR DESCRIPTION
Se corrigio un error en el que cuando el artista estaba almacenado localmente solo se mostraba [*]